### PR TITLE
refactor: update color system

### DIFF
--- a/.changeset/shiny-chicken-play.md
+++ b/.changeset/shiny-chicken-play.md
@@ -1,0 +1,5 @@
+---
+"@pedaki/design": patch
+---
+
+Simpler color system

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -54,6 +54,4 @@ import '@pedaki/design/styles.css';
 
 ### Color system
 
-| UseCase    | What to use                     |
-|------------|---------------------------------|
-| Focus Ring | `orange-300 dark:orange-500/40` |
+TODO

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -51,3 +51,9 @@ And import the global styles in your `layout.tsx`:
 ```tsx file=index.tsx
 import '@pedaki/design/styles.css';
 ```
+
+### Color system
+
+| UseCase    | What to use                     |
+|------------|---------------------------------|
+| Focus Ring | `orange-300 dark:orange-500/40` |

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -55,11 +55,11 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "mini-svg-data-uri": "^1.4.4",
+    "react-hook-form": "^7.46.1",
     "sass": "^1.66.1",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "^3.3.3",
-    "tailwindcss-animate": "^1.0.7",
-    "react-hook-form": "^7.46.1"
+    "tailwindcss-animate": "^1.0.7"
   },
   "peerDependenciesMeta": {
     "react-hook-form": {

--- a/packages/design/src/tailwind/index.css
+++ b/packages/design/src/tailwind/index.css
@@ -21,7 +21,6 @@
     --gray-850: 26 26 26; /* #1a1a1a */
     --gray-900: 25 22 21; /* #191615 */
 
-    --ring: var(--orange-300);
     --radius: 0.5rem;
 
     --background-primary: var(--white);

--- a/packages/design/src/tailwind/index.css
+++ b/packages/design/src/tailwind/index.css
@@ -25,6 +25,7 @@
 
     --background-primary: var(--white);
     --background-secondary: var(--gray-50);
+    --background-tertiary: var(--gray-100);
 
     --text-primary: var(--gray-850);
     --text-secondary: var(--gray-600);
@@ -44,6 +45,11 @@
 
   * {
     border-color: rgb(var(--border) / 1);
+  }
+
+  a {
+    width: fit-content;
+    display: inline-block;
   }
 
   html {

--- a/packages/design/src/tailwind/index.css
+++ b/packages/design/src/tailwind/index.css
@@ -3,59 +3,59 @@
 @tailwind utilities;
 
 @layer base {
-    :root {
+  :root {
+    --orange-300: 252 156 102; /* #FC9C66 */
+    --orange-500: 243 88 21; /* #f35815 */
 
-        --orange-300: 252 156 102; /* #FC9C66 */
-        --orange-500: 243 88 21; /* #f35815 */
+    --white: 255 255 255; /* #FFFFFF */
 
-        --white: 255 255 255; /* #FFFFFF */
+    --gray-50: 244 245 248; /* #F4F5F8 */
+    --gray-100: 249 249 249; /* #F9F9F9 */
+    --gray-200: 225 225 225; /* #E1E1E1 */
+    --gray-300: 193 193 193; /* #C1C1C1 */
+    --gray-400: 161 161 161; /* #A1A1A1 */
+    --gray-500: 129 129 129; /* #818181 */
+    --gray-600: 97 97 97; /* #616161 */
+    --gray-700: 65 65 65; /* #414141 */
+    --gray-800: 28 25 23; /* #1C1917 */
+    --gray-850: 26 26 26; /* #1a1a1a */
+    --gray-900: 25 22 21; /* #191615 */
 
-        --gray-50: 244 245 248; /* #F4F5F8 */
-        --gray-100: 249 249 249; /* #F9F9F9 */
-        --gray-200: 225 225 225; /* #E1E1E1 */
-        --gray-300: 193 193 193; /* #C1C1C1 */
-        --gray-400: 161 161 161; /* #A1A1A1 */
-        --gray-500: 129 129 129; /* #818181 */
-        --gray-600: 97 97 97; /* #616161 */
-        --gray-700: 65 65 65; /* #414141 */
-        --gray-800: 28 25 23; /* #1C1917 */
-        --gray-850: 26 26 26; /* #1a1a1a */
-        --gray-900: 25 22 21; /* #191615 */
+    --ring: var(--orange-300);
+    --radius: 0.5rem;
 
-        --ring: var(--orange-300);
-        --radius: 0.5rem;
+    --background-primary: var(--white);
+    --background-secondary: var(--gray-50);
 
-        --background-primary: var(--white);
-        --background-secondary: var(--gray-50);
+    --text-primary: var(--gray-850);
+    --text-secondary: var(--gray-600);
+    --text-muted: var(--gray-500);
 
-        --text-primary: var(--gray-850);
-        --text-secondary: var(--gray-600);
-        --text-muted: var(--gray-500);
+    --border: var(--gray-200);
+  }
 
-        --border: var(--gray-100);
-    }
+  .dark {
+    --text-primary: var(--gray-50);
+    --text-secondary: var(--gray-400);
+    --text-muted: var(--gray-500);
 
-    .dark {
-        --text-primary: var(--gray-50);
-        --text-secondary: var(--gray-400);
-        --text-muted: var(--gray-500);
+    --background-primary: var(--gray-900);
+    --background-secondary: var(--gray-850);
+  }
 
-        --background-primary: var(--gray-900);
-        --background-secondary: var(--gray-850);
-    }
+  * {
+    border-color: rgb(var(--border) / 1);
+  }
 
-    * {
-        border-color: rgb(var(--border));
-    }
+  html {
+    scroll-behavior: smooth;
+    @apply min-h-full;
+  }
 
-    html {
-        scroll-behavior: smooth;
-        @apply min-h-full;
-    }
-
-    body {
-        @apply bg-primary text-primary flex min-h-full flex-col justify-between antialiased;
-        text-rendering: optimizeLegibility;
-        font-feature-settings: 'cv11", "salt", "ss01", "ss03", "cv01", "cv02", "cv03", "cv04", "cv05", "cv06", "cv07", "cv08", "cv09", "cv10';
-    }
+  body {
+    @apply bg-primary text-primary flex min-h-full flex-col justify-between antialiased;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: 'cv11', 'salt', 'ss01', 'ss03', 'cv01', 'cv02', 'cv03', 'cv04', 'cv05',
+      'cv06', 'cv07', 'cv08', 'cv09', 'cv10';
+  }
 }

--- a/packages/design/src/tailwind/index.css
+++ b/packages/design/src/tailwind/index.css
@@ -55,7 +55,6 @@
   html {
     scroll-behavior: smooth;
     @apply min-h-full;
-    color: rgb(var(--text-primary) / 1);
   }
 
   body {

--- a/packages/design/src/tailwind/index.css
+++ b/packages/design/src/tailwind/index.css
@@ -3,84 +3,59 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --background: 210 20% 98%;
-    --foreground: 20 14.3% 4.1%;
+    :root {
 
-    --card: 0 0% 100%;
-    --card-foreground: 20 14.3% 4.1%;
+        --orange-300: 252 156 102; /* #FC9C66 */
+        --orange-500: 243 88 21; /* #f35815 */
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 20 14.3% 4.1%;
+        --white: 255 255 255; /* #FFFFFF */
 
-    --primary: 24.6 95% 53.1%;
-    --primary-foreground: 60 9.1% 97.8%;
+        --gray-50: 244 245 248; /* #F4F5F8 */
+        --gray-100: 249 249 249; /* #F9F9F9 */
+        --gray-200: 225 225 225; /* #E1E1E1 */
+        --gray-300: 193 193 193; /* #C1C1C1 */
+        --gray-400: 161 161 161; /* #A1A1A1 */
+        --gray-500: 129 129 129; /* #818181 */
+        --gray-600: 97 97 97; /* #616161 */
+        --gray-700: 65 65 65; /* #414141 */
+        --gray-800: 28 25 23; /* #1C1917 */
+        --gray-850: 26 26 26; /* #1a1a1a */
+        --gray-900: 25 22 21; /* #191615 */
 
-    --secondary: 60 4.8% 95.9%;
-    --secondary-foreground: 24 9.8% 10%;
+        --ring: var(--orange-300);
+        --radius: 0.5rem;
 
-    --muted: 60 4.8% 95.9%;
-    --muted-foreground: 25 5.3% 44.7%;
+        --background-primary: var(--white);
+        --background-secondary: var(--gray-50);
 
-    --accent: 60 4.8% 95.9%;
-    --accent-foreground: 24 9.8% 10%;
+        --text-primary: var(--gray-850);
+        --text-secondary: var(--gray-600);
+        --text-muted: var(--gray-500);
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 60 9.1% 97.8%;
+        --border: var(--gray-100);
+    }
 
-    --border: 20 5.9% 90%;
-    --input: 20 5.9% 90%;
+    .dark {
+        --text-primary: var(--gray-50);
+        --text-secondary: var(--gray-400);
+        --text-muted: var(--gray-500);
 
-    --ring: 24.6 95% 53.1%;
+        --background-primary: var(--gray-900);
+        --background-secondary: var(--gray-850);
+    }
 
-    --radius: 0.5rem;
-  }
+    * {
+        border-color: rgb(var(--border));
+    }
 
-  .dark {
-    --background: 6 7% 9%;
-    --foreground: 60 9.1% 97.8%;
+    html {
+        scroll-behavior: smooth;
+        @apply min-h-full;
+    }
 
-    --card: 20 14.3% 4.1%;
-    --card-foreground: 60 9.1% 97.8%;
-
-    --popover: 20 14.3% 4.1%;
-    --popover-foreground: 60 9.1% 97.8%;
-
-    --primary: 20.5 90.2% 48.2%;
-    --primary-foreground: 60 9.1% 97.8%;
-
-    --secondary: 12 6.5% 15.1%;
-    --secondary-foreground: 60 9.1% 97.8%;
-
-    --muted: 12 6.5% 15.1%;
-    --muted-foreground: 24 5.4% 63.9%;
-
-    --accent: 12 6.5% 15.1%;
-    --accent-foreground: 60 9.1% 97.8%;
-
-    --destructive: 0 72.2% 50.6%;
-    --destructive-foreground: 60 9.1% 97.8%;
-
-    --border: 12 6.5% 15.1%;
-    --input: 12 6.5% 15.1%;
-    --ring: 20.5 90.2% 48.2%;
-  }
-}
-
-@layer base {
-  * {
-    @apply border-border;
-  }
-
-  html {
-    scroll-behavior: smooth;
-    @apply min-h-full;
-  }
-
-  body {
-    @apply bg-background text-foreground flex min-h-full flex-col justify-between antialiased;
-    font-feature-settings:
-      'rlig' 1,
-      'calt' 1;
-  }
+    body {
+        @apply bg-primary text-primary flex min-h-full flex-col justify-between antialiased;
+        text-rendering: optimizeLegibility;
+        font-feature-settings: 'cv11", "salt", "ss01", "ss03", "cv01", "cv02", "cv03", "cv04", "cv05", "cv06", "cv07", "cv08", "cv09", "cv10';
+    }
 }

--- a/packages/design/src/tailwind/index.css
+++ b/packages/design/src/tailwind/index.css
@@ -9,8 +9,8 @@
 
     --white: 255 255 255; /* #FFFFFF */
 
-    --gray-50: 244 245 248; /* #F4F5F8 */
-    --gray-100: 249 249 249; /* #F9F9F9 */
+    --gray-50: 249 249 249; /* #F9F9F9 */
+    --gray-100: 244 245 248; /* #F4F5F8 */
     --gray-200: 225 225 225; /* #E1E1E1 */
     --gray-300: 193 193 193; /* #C1C1C1 */
     --gray-400: 161 161 161; /* #A1A1A1 */
@@ -49,6 +49,7 @@
   html {
     scroll-behavior: smooth;
     @apply min-h-full;
+    color: rgb(var(--text-primary) / 1);
   }
 
   body {

--- a/packages/design/src/tailwind/tailwind.config.ts
+++ b/packages/design/src/tailwind/tailwind.config.ts
@@ -1,95 +1,93 @@
 import svgToDataUri from 'mini-svg-data-uri';
-import type {Config} from 'tailwindcss';
-import {fontFamily} from 'tailwindcss/defaultTheme';
+import type { Config } from 'tailwindcss';
+import { fontFamily } from 'tailwindcss/defaultTheme';
 // @ts-expect-error - no types
 import flattenColorPalette from 'tailwindcss/lib/util/flattenColorPalette';
 import plugin from 'tailwindcss/plugin';
 
-const gridBackground = plugin(({matchUtilities, theme}) => {
-    matchUtilities(
-        {
-            'bgi-grid': (value: string) => ({
-                backgroundImage: `url("${svgToDataUri(
-                    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="${value}"><path d="M0 .5H31.5V32"/></svg>`,
-                )}")`,
-            }),
-        },
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
-        {values: flattenColorPalette(theme('backgroundColor')), type: 'color'},
-    );
+const gridBackground = plugin(({ matchUtilities, theme }) => {
+  matchUtilities(
+    {
+      'bgi-grid': (value: string) => ({
+        backgroundImage: `url("${svgToDataUri(
+          `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="${value}"><path d="M0 .5H31.5V32"/></svg>`,
+        )}")`,
+      }),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
+    { values: flattenColorPalette(theme('backgroundColor')), type: 'color' },
+  );
 });
 
 export default {
-    darkMode: ['class'],
-    theme: {
-        container: {
-            center: true,
-            padding: '2rem',
-            screens: {
-                '2xl': '1400px',
-            },
-        },
-        extend: {
-            colors: {
-                gray: {
-                    50: 'rgb(var(--gray-50) / <alpha-value>)',
-                    100: 'rgb(var(--gray-100) / <alpha-value>)',
-                    200: 'rgb(var(--gray-200) / <alpha-value>)',
-                    300: 'rgb(var(--gray-300) / <alpha-value>)',
-                    400: 'rgb(var(--gray-400) / <alpha-value>)',
-                    500: 'rgb(var(--gray-500) / <alpha-value>)',
-                    600: 'rgb(var(--gray-600) / <alpha-value>)',
-                    700: 'rgb(var(--gray-700) / <alpha-value>)',
-                    800: 'rgb(var(--gray-800) / <alpha-value>)',
-                    850: 'rgb(var(--gray-850) / <alpha-value>)',
-                    900: 'rgb(var(--gray-900) / <alpha-value>)',
-                },
-                orange: {
-                    300: 'rgb(var(--orange-300) / <alpha-value>)',
-                    500: 'rgb(var(--orange-500) / <alpha-value>)',
-                    DEFAULT: 'rgb(var(--orange-500) / <alpha-value>)',
-                }
-            },
-            backgroundColor: {
-                'primary': 'rgb(var(--background-primary) / <alpha-value>)',
-                'secondary': 'rgb(var(--background-secondary) / <alpha-value>)',
-            },
-            textColor: {
-                'primary': 'rgb(var(--text-primary) / <alpha-value>)',
-                'secondary': 'rgb(var(--text-secondary) / <alpha-value>)',
-                'muted': 'rgb(var(--text-muted) / <alpha-value>)',
-            },
-            borderColor: {
-
-            },
-            borderRadius: {
-                lg: 'var(--radius)',
-                md: 'calc(var(--radius) - 2px)',
-                sm: 'calc(var(--radius) - 4px)',
-            },
-            fontFamily: {
-                sans: ['var(--font-sans)', ...fontFamily.sans],
-                mono: ['var(--font-mono)', ...fontFamily.mono],
-            },
-            keyframes: {
-                'accordion-down': {
-                    from: {height: '0'},
-                    to: {height: 'var(--radix-accordion-content-height)'},
-                },
-                'accordion-up': {
-                    from: {height: 'var(--radix-accordion-content-height)'},
-                    to: {height: '0'},
-                },
-            },
-            animation: {
-                'accordion-down': 'accordion-down 0.2s ease-out',
-                'accordion-up': 'accordion-up 0.2s ease-out',
-            },
-            boxShadow: {
-                outline: 'var(--shadow-outline) 0 0 0 6px',
-                'outline-lg': 'var(--shadow-outline) 0 0 0 8px',
-            },
-        },
+  darkMode: ['class'],
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
     },
-    plugins: [require('tailwindcss-animate'), gridBackground],
+    extend: {
+      colors: {
+        gray: {
+          50: 'rgb(var(--gray-50) / <alpha-value>)',
+          100: 'rgb(var(--gray-100) / <alpha-value>)',
+          200: 'rgb(var(--gray-200) / <alpha-value>)',
+          300: 'rgb(var(--gray-300) / <alpha-value>)',
+          400: 'rgb(var(--gray-400) / <alpha-value>)',
+          500: 'rgb(var(--gray-500) / <alpha-value>)',
+          600: 'rgb(var(--gray-600) / <alpha-value>)',
+          700: 'rgb(var(--gray-700) / <alpha-value>)',
+          800: 'rgb(var(--gray-800) / <alpha-value>)',
+          850: 'rgb(var(--gray-850) / <alpha-value>)',
+          900: 'rgb(var(--gray-900) / <alpha-value>)',
+        },
+        orange: {
+          300: 'rgb(var(--orange-300) / <alpha-value>)',
+          500: 'rgb(var(--orange-500) / <alpha-value>)',
+          DEFAULT: 'rgb(var(--orange-500) / <alpha-value>)',
+        },
+      },
+      backgroundColor: {
+        primary: 'rgb(var(--background-primary) / <alpha-value>)',
+        secondary: 'rgb(var(--background-secondary) / <alpha-value>)',
+      },
+      textColor: {
+        primary: 'rgb(var(--text-primary) / <alpha-value>)',
+        secondary: 'rgb(var(--text-secondary) / <alpha-value>)',
+        muted: 'rgb(var(--text-muted) / <alpha-value>)',
+      },
+      borderColor: {},
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)', ...fontFamily.sans],
+        mono: ['var(--font-mono)', ...fontFamily.mono],
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+      boxShadow: {
+        outline: 'var(--shadow-outline) 0 0 0 6px',
+        'outline-lg': 'var(--shadow-outline) 0 0 0 8px',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate'), gridBackground],
 } satisfies Omit<Config, 'content'>;

--- a/packages/design/src/tailwind/tailwind.config.ts
+++ b/packages/design/src/tailwind/tailwind.config.ts
@@ -1,101 +1,95 @@
 import svgToDataUri from 'mini-svg-data-uri';
-import type { Config } from 'tailwindcss';
-import { fontFamily } from 'tailwindcss/defaultTheme';
+import type {Config} from 'tailwindcss';
+import {fontFamily} from 'tailwindcss/defaultTheme';
 // @ts-expect-error - no types
 import flattenColorPalette from 'tailwindcss/lib/util/flattenColorPalette';
 import plugin from 'tailwindcss/plugin';
 
-const gridBackground = plugin(({ matchUtilities, theme }) => {
-  matchUtilities(
-    {
-      'bgi-grid': (value: string) => ({
-        backgroundImage: `url("${svgToDataUri(
-          `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="${value}"><path d="M0 .5H31.5V32"/></svg>`,
-        )}")`,
-      }),
-    },
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
-    { values: flattenColorPalette(theme('backgroundColor')), type: 'color' },
-  );
+const gridBackground = plugin(({matchUtilities, theme}) => {
+    matchUtilities(
+        {
+            'bgi-grid': (value: string) => ({
+                backgroundImage: `url("${svgToDataUri(
+                    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="${value}"><path d="M0 .5H31.5V32"/></svg>`,
+                )}")`,
+            }),
+        },
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
+        {values: flattenColorPalette(theme('backgroundColor')), type: 'color'},
+    );
 });
 
 export default {
-  darkMode: ['class'],
-  theme: {
-    container: {
-      center: true,
-      padding: '2rem',
-      screens: {
-        '2xl': '1400px',
-      },
+    darkMode: ['class'],
+    theme: {
+        container: {
+            center: true,
+            padding: '2rem',
+            screens: {
+                '2xl': '1400px',
+            },
+        },
+        extend: {
+            colors: {
+                gray: {
+                    50: 'rgb(var(--gray-50) / <alpha-value>)',
+                    100: 'rgb(var(--gray-100) / <alpha-value>)',
+                    200: 'rgb(var(--gray-200) / <alpha-value>)',
+                    300: 'rgb(var(--gray-300) / <alpha-value>)',
+                    400: 'rgb(var(--gray-400) / <alpha-value>)',
+                    500: 'rgb(var(--gray-500) / <alpha-value>)',
+                    600: 'rgb(var(--gray-600) / <alpha-value>)',
+                    700: 'rgb(var(--gray-700) / <alpha-value>)',
+                    800: 'rgb(var(--gray-800) / <alpha-value>)',
+                    850: 'rgb(var(--gray-850) / <alpha-value>)',
+                    900: 'rgb(var(--gray-900) / <alpha-value>)',
+                },
+                orange: {
+                    300: 'rgb(var(--orange-300) / <alpha-value>)',
+                    500: 'rgb(var(--orange-500) / <alpha-value>)',
+                    DEFAULT: 'rgb(var(--orange-500) / <alpha-value>)',
+                }
+            },
+            backgroundColor: {
+                'primary': 'rgb(var(--background-primary) / <alpha-value>)',
+                'secondary': 'rgb(var(--background-secondary) / <alpha-value>)',
+            },
+            textColor: {
+                'primary': 'rgb(var(--text-primary) / <alpha-value>)',
+                'secondary': 'rgb(var(--text-secondary) / <alpha-value>)',
+                'muted': 'rgb(var(--text-muted) / <alpha-value>)',
+            },
+            borderColor: {
+
+            },
+            borderRadius: {
+                lg: 'var(--radius)',
+                md: 'calc(var(--radius) - 2px)',
+                sm: 'calc(var(--radius) - 4px)',
+            },
+            fontFamily: {
+                sans: ['var(--font-sans)', ...fontFamily.sans],
+                mono: ['var(--font-mono)', ...fontFamily.mono],
+            },
+            keyframes: {
+                'accordion-down': {
+                    from: {height: '0'},
+                    to: {height: 'var(--radix-accordion-content-height)'},
+                },
+                'accordion-up': {
+                    from: {height: 'var(--radix-accordion-content-height)'},
+                    to: {height: '0'},
+                },
+            },
+            animation: {
+                'accordion-down': 'accordion-down 0.2s ease-out',
+                'accordion-up': 'accordion-up 0.2s ease-out',
+            },
+            boxShadow: {
+                outline: 'var(--shadow-outline) 0 0 0 6px',
+                'outline-lg': 'var(--shadow-outline) 0 0 0 8px',
+            },
+        },
     },
-    extend: {
-      colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
-        primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
-        },
-        secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
-        },
-        destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
-        },
-        muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
-        },
-        accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
-        },
-        popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
-        },
-        card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
-        },
-      },
-      borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
-      },
-      fontFamily: {
-        sans: ['var(--font-sans)', ...fontFamily.sans],
-        mono: ['var(--font-mono)', ...fontFamily.mono],
-      },
-      fontSize: {
-        sm2: '0.9rem',
-      },
-      keyframes: {
-        'accordion-down': {
-          from: { height: '0' },
-          to: { height: 'var(--radix-accordion-content-height)' },
-        },
-        'accordion-up': {
-          from: { height: 'var(--radix-accordion-content-height)' },
-          to: { height: '0' },
-        },
-      },
-      animation: {
-        'accordion-down': 'accordion-down 0.2s ease-out',
-        'accordion-up': 'accordion-up 0.2s ease-out',
-      },
-      boxShadow: {
-        outline: 'var(--shadow-outline) 0 0 0 6px',
-        'outline-lg': 'var(--shadow-outline) 0 0 0 8px',
-      },
-    },
-  },
-  plugins: [require('tailwindcss-animate'), gridBackground],
+    plugins: [require('tailwindcss-animate'), gridBackground],
 } satisfies Omit<Config, 'content'>;

--- a/packages/design/src/tailwind/tailwind.config.ts
+++ b/packages/design/src/tailwind/tailwind.config.ts
@@ -53,6 +53,8 @@ export default {
       backgroundColor: {
         primary: 'rgb(var(--background-primary) / <alpha-value>)',
         secondary: 'rgb(var(--background-secondary) / <alpha-value>)',
+        tertiary: 'rgb(var(--background-tertiary) / <alpha-value>)',
+        border: 'rgb(var(--border) / <alpha-value>)',
       },
       textColor: {
         primary: 'rgb(var(--text-primary) / <alpha-value>)',
@@ -62,11 +64,15 @@ export default {
       borderColor: {
         primary: 'rgb(var(--text-primary) / <alpha-value>)',
         secondary: 'rgb(var(--text-secondary) / <alpha-value>)',
+        border: 'rgb(var(--border) / <alpha-value>)',
       },
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
+      },
+      ringOffsetColor: {
+        'bg-primary': 'rgb(var(--background-primary) / <alpha-value>)',
       },
       fontFamily: {
         sans: ['var(--font-sans)', ...fontFamily.sans],

--- a/packages/design/src/tailwind/tailwind.config.ts
+++ b/packages/design/src/tailwind/tailwind.config.ts
@@ -59,7 +59,10 @@ export default {
         secondary: 'rgb(var(--text-secondary) / <alpha-value>)',
         muted: 'rgb(var(--text-muted) / <alpha-value>)',
       },
-      borderColor: {},
+      borderColor: {
+        primary: 'rgb(var(--text-primary) / <alpha-value>)',
+        secondary: 'rgb(var(--text-secondary) / <alpha-value>)',
+      },
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',

--- a/packages/design/src/ui/accordion.tsx
+++ b/packages/design/src/ui/accordion.tsx
@@ -42,7 +42,9 @@ const AccordionContent = React.forwardRef<
   <AccordionPrimitive.Content
     ref={ref}
     className={cn(
-      'data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm transition-all',
+      'text-secondary',
+      'overflow-hidden text-sm transition-all',
+      'data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down ',
       className,
     )}
     {...props}

--- a/packages/design/src/ui/badge.tsx
+++ b/packages/design/src/ui/badge.tsx
@@ -4,20 +4,15 @@ import * as React from 'react';
 import { cn } from '../utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2',
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
-        secondary:
-          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        destructive:
-          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
-        outline: 'text-foreground',
+        outline: '',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'outline',
     },
   },
 );

--- a/packages/design/src/ui/badge.tsx
+++ b/packages/design/src/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { cn } from '../utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2',
+  'bg-white inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-orange focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/packages/design/src/ui/button.tsx
+++ b/packages/design/src/ui/button.tsx
@@ -2,13 +2,12 @@ import { Slot } from '@radix-ui/react-slot';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 import * as React from 'react';
-import { cn } from '../utils/cn';
+import { cn } from '../utils';
 
 const buttonVariants = cva(
   [
     'group inline-flex items-center text-center justify-center gap-sm text-sm no-underline font-medium transition-colors gap-2',
     'disabled:text-gray-600',
-    '',
     'text-primary disabled:text-gray-300',
     'bg-white disabled:bg-gray-200',
     'disabled:cursor-not-allowed',

--- a/packages/design/src/ui/button.tsx
+++ b/packages/design/src/ui/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
   [
     'group inline-flex items-center text-center justify-center gap-sm text-sm no-underline font-medium transition-colors gap-2',
     'disabled:text-gray-600',
-    'ring-offset-background  focus-visible:outline-none focus:ring-2 focus:ring-orange-300 focus:ring-offset-2',
+    'ring-offset-background  focus-visible:outline-none focus:ring-2 focus:ring-orange-300 focus:ring-offset-1',
     'text-primary disabled:text-gray-300',
     'bg-white disabled:bg-gray-200',
     'disabled:cursor-not-allowed',
@@ -17,12 +17,14 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        outline: 'border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        orange: [
+        outline: '',
+        orange_outline: [
           'bg-orange hover:bg-white',
           'border-orange-500 disabled:border-gray-200',
           'text-white hover:text-primary',
         ],
+        neutral: ['bg-gray-850', 'border-gray-850 hover:border-gray-800', 'text-white'],
+        orange: ['bg-orange', 'border-orange-500 hover:border-orange-600', 'text-white'],
         transparent: [
           'text-primary hover:text-orange',
           'bg-transparent',
@@ -32,6 +34,7 @@ const buttonVariants = cva(
       size: {
         default: 'h-10 px-4 py-2',
         sm: 'h-5 px-2',
+        lg: 'h-12 px-6 py-3',
         icon: 'h-10 w-10',
       },
       rounded: {
@@ -40,7 +43,7 @@ const buttonVariants = cva(
       },
     },
     defaultVariants: {
-      variant: 'outline',
+      variant: 'neutral',
       size: 'default',
       rounded: 'default',
     },

--- a/packages/design/src/ui/button.tsx
+++ b/packages/design/src/ui/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
   [
     'group inline-flex items-center text-center justify-center gap-sm text-sm no-underline font-medium transition-colors gap-2',
     'disabled:text-gray-600',
-    'ring-offset-background  focus-visible:outline-none focus:ring-2 focus:ring-orange-300 focus:ring-offset-1',
+    '',
     'text-primary disabled:text-gray-300',
     'bg-white disabled:bg-gray-200',
     'disabled:cursor-not-allowed',
@@ -41,11 +41,19 @@ const buttonVariants = cva(
         default: 'rounded-md',
         full: 'rounded-full',
       },
+      ring: {
+        default: [
+          'ring-offset-bg-primary focus-visible:outline-none focus:ring-2 focus:ring-orange-300 focus:ring-offset-1',
+          'data-[state=open]:ring-2 data-[state=open]:ring-orange-300 data-[state=open]:ring-offset-1',
+        ],
+        none: '',
+      },
     },
     defaultVariants: {
       variant: 'neutral',
       size: 'default',
       rounded: 'default',
+      ring: 'default',
     },
   },
 );
@@ -57,11 +65,11 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, rounded, asChild = false, ...props }, ref) => {
+  ({ className, variant, ring, size, rounded, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, rounded, className }))}
+        className={cn(buttonVariants({ variant, size, ring, rounded, className }))}
         ref={ref}
         {...props}
       />

--- a/packages/design/src/ui/button.tsx
+++ b/packages/design/src/ui/button.tsx
@@ -1,31 +1,48 @@
 import { Slot } from '@radix-ui/react-slot';
-import { cva } from 'class-variance-authority';
 import type { VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 import * as React from 'react';
-import { cn } from '../utils';
+import { cn } from '../utils/cn';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  [
+    'group inline-flex items-center text-center justify-center gap-sm text-sm no-underline font-medium transition-colors gap-2',
+    'disabled:text-gray-600',
+    'ring-offset-background  focus-visible:outline-none focus:ring-2 focus:ring-orange-300 focus:ring-offset-2',
+    'text-primary disabled:text-gray-300',
+    'bg-white disabled:bg-gray-200',
+    'disabled:cursor-not-allowed',
+    'border hover:border-orange-500 disabled:hover:border-gray-200',
+  ],
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+        outline: 'border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        orange: [
+          'bg-orange hover:bg-white',
+          'border-orange-500 disabled:border-gray-200',
+          'text-white hover:text-primary',
+        ],
+        transparent: [
+          'text-primary hover:text-orange',
+          'bg-transparent',
+          'border-none hover:border-none',
+        ],
       },
       size: {
         default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
+        sm: 'h-5 px-2',
         icon: 'h-10 w-10',
+      },
+      rounded: {
+        default: 'rounded-md',
+        full: 'rounded-full',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'outline',
       size: 'default',
+      rounded: 'default',
     },
   },
 );
@@ -37,10 +54,14 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, rounded, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        className={cn(buttonVariants({ variant, size, rounded, className }))}
+        ref={ref}
+        {...props}
+      />
     );
   },
 );

--- a/packages/design/src/ui/card.tsx
+++ b/packages/design/src/ui/card.tsx
@@ -8,7 +8,10 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'bg-card text-card-foreground rounded-lg border',
+      'text-card-foreground bg-white',
+      'border',
+      'rounded-lg',
+      'text-primary',
       withShadow && 'shadow-sm',
       className,
     )}
@@ -39,7 +42,7 @@ const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn('text-muted-foreground text-sm', className)} {...props} />
+  <p ref={ref} className={cn('text-secondary text-sm', className)} {...props} />
 ));
 CardDescription.displayName = 'CardDescription';
 

--- a/packages/design/src/ui/dialog.tsx
+++ b/packages/design/src/ui/dialog.tsx
@@ -21,7 +21,9 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'bg-background/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 backdrop-blur-sm',
+      'bg-primary/80',
+      'fixed inset-0 z-50 backdrop-blur-sm',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -38,13 +40,15 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 md:w-full',
+        'bg-primary',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 md:w-full',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+      <DialogPrimitive.Close className="ring-offset-bg-primary focus:ring-orange data-[state=open]:bg-accent data-[state=open]:text-muted absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
         <IconX className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -84,7 +88,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-muted-foreground text-sm', className)}
+    className={cn('text-secondary text-sm', className)}
     {...props}
   />
 ));

--- a/packages/design/src/ui/dropdown-menu.tsx
+++ b/packages/design/src/ui/dropdown-menu.tsx
@@ -28,7 +28,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'focus:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
+      'focus:bg-orange data-[state=open]:bg-accent flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
       inset && 'pl-8',
       className,
     )}
@@ -47,7 +47,10 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg',
+      'bg-white',
+      'text-secondary',
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}
@@ -64,7 +67,10 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md',
+        'bg-white',
+        'text-secondary',
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}
@@ -82,7 +88,9 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'focus:bg-tertiary',
+      'focus:text-secondary',
       inset && 'pl-8',
       className,
     )}
@@ -98,7 +106,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'focus:bg-tertiary',
+      'focus:text-secondary',
       className,
     )}
     checked={checked}
@@ -121,7 +131,9 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'focus:bg-tertiary',
+      'focus:text-secondary',
       className,
     )}
     {...props}
@@ -156,7 +168,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('bg-muted -mx-1 my-1 h-px', className)}
+    className={cn('bg-border -mx-1 my-1 h-px', className)}
     {...props}
   />
 ));

--- a/packages/design/src/ui/form.tsx
+++ b/packages/design/src/ui/form.tsx
@@ -117,7 +117,7 @@ const FormDescription = React.forwardRef<
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-secondary text-sm', className)}
       {...props}
     />
   );

--- a/packages/design/src/ui/input.tsx
+++ b/packages/design/src/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'bg-primary ring-offset-bg-primary placeholder:text-muted focus-visible:ring-orange flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/packages/design/src/ui/navigation-menu.tsx
+++ b/packages/design/src/ui/navigation-menu.tsx
@@ -79,7 +79,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn('absolute left-0 top-full flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        'origin-top-center bg-white text-primary data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow-lg md:w-[var(--radix-navigation-menu-viewport-width)]',
+        'origin-top-center text-primary data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-white shadow-lg md:w-[var(--radix-navigation-menu-viewport-width)]',
         className,
       )}
       ref={ref}

--- a/packages/design/src/ui/navigation-menu.tsx
+++ b/packages/design/src/ui/navigation-menu.tsx
@@ -33,9 +33,10 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
-const navigationMenuTriggerStyle = cva(
-  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium transition-colors hover:bg-secondary/50 hover:text-orange focus:bg-secondary/50 focus:text-orange focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active=true]:bg-secondary/50 data-[state=open]:bg-secondary/50 data-[state=open]:text-orange',
-);
+const navigationMenuTriggerStyle = cva([
+  'hover:bg-secondary/80 data-[state=open]:bg-secondary/80 data-[active=true]:bg-secondary/80',
+  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium transition-colors hover:text-orange focus:bg-secondary/50 focus:text-orange focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=open]:text-orange',
+]);
 
 const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,

--- a/packages/design/src/ui/navigation-menu.tsx
+++ b/packages/design/src/ui/navigation-menu.tsx
@@ -34,7 +34,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent/50 hover:text-accent-foreground focus:bg-accent/50 focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active=true]:bg-accent/50 data-[state=open]:bg-accent/50',
+  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium transition-colors hover:bg-secondary/50 hover:text-orange focus:bg-secondary/50 focus:text-orange focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active=true]:bg-secondary/50 data-[state=open]:bg-secondary/50 data-[state=open]:text-orange',
 );
 
 const NavigationMenuTrigger = React.forwardRef<
@@ -79,7 +79,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn('absolute left-0 top-full flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        'origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow-lg md:w-[var(--radix-navigation-menu-viewport-width)]',
+        'origin-top-center bg-white text-primary data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow-lg md:w-[var(--radix-navigation-menu-viewport-width)]',
         className,
       )}
       ref={ref}

--- a/packages/design/src/ui/skeleton.tsx
+++ b/packages/design/src/ui/skeleton.tsx
@@ -1,7 +1,7 @@
 import { cn } from '../utils';
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('bg-muted animate-pulse rounded-md', className)} {...props} />;
+  return <div className={cn('bg-tertiary animate-pulse rounded-md', className)} {...props} />;
 }
 
 export { Skeleton };

--- a/packages/design/src/ui/slider.tsx
+++ b/packages/design/src/ui/slider.tsx
@@ -16,7 +16,7 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="bg-secondary relative h-2 w-full grow overflow-hidden rounded-full">
       <SliderPrimitive.Range className="bg-primary absolute h-full" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="border-primary bg-background ring-offset-background focus-visible:ring-ring block h-5 w-5 rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="border-primary bg-primary ring-offset-bg-primary focus-visible:ring-orange block h-5 w-5 rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/packages/design/src/ui/tooltip.tsx
+++ b/packages/design/src/ui/tooltip.tsx
@@ -18,7 +18,10 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'bg-popover text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md',
+      'bg-white',
+      'text-secondary',
+      'z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md',
+      'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 5.0.1
       turbo:
         specifier: latest
-        version: 1.10.13
+        version: 1.10.14
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -7768,64 +7768,64 @@ packages:
       yargs: 17.7.2
     dev: true
 
-  /turbo-darwin-64@1.10.13:
-    resolution: {integrity: sha512-vmngGfa2dlYvX7UFVncsNDMuT4X2KPyPJ2Jj+xvf5nvQnZR/3IeDEGleGVuMi/hRzdinoxwXqgk9flEmAYp0Xw==}
+  /turbo-darwin-64@1.10.14:
+    resolution: {integrity: sha512-I8RtFk1b9UILAExPdG/XRgGQz95nmXPE7OiGb6ytjtNIR5/UZBS/xVX/7HYpCdmfriKdVwBKhalCoV4oDvAGEg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.10.13:
-    resolution: {integrity: sha512-eMoJC+k7gIS4i2qL6rKmrIQGP6Wr9nN4odzzgHFngLTMimok2cGLK3qbJs5O5F/XAtEeRAmuxeRnzQwTl/iuAw==}
+  /turbo-darwin-arm64@1.10.14:
+    resolution: {integrity: sha512-KAdUWryJi/XX7OD0alOuOa0aJ5TLyd4DNIYkHPHYcM6/d7YAovYvxRNwmx9iv6Vx6IkzTnLeTiUB8zy69QkG9Q==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.10.13:
-    resolution: {integrity: sha512-0CyYmnKTs6kcx7+JRH3nPEqCnzWduM0hj8GP/aodhaIkLNSAGAa+RiYZz6C7IXN+xUVh5rrWTnU2f1SkIy7Gdg==}
+  /turbo-linux-64@1.10.14:
+    resolution: {integrity: sha512-BOBzoREC2u4Vgpap/WDxM6wETVqVMRcM8OZw4hWzqCj2bqbQ6L0wxs1LCLWVrghQf93JBQtIGAdFFLyCSBXjWQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.10.13:
-    resolution: {integrity: sha512-0iBKviSGQQlh2OjZgBsGjkPXoxvRIxrrLLbLObwJo3sOjIH0loGmVIimGS5E323soMfi/o+sidjk2wU1kFfD7Q==}
+  /turbo-linux-arm64@1.10.14:
+    resolution: {integrity: sha512-D8T6XxoTdN5D4V5qE2VZG+/lbZX/89BkAEHzXcsSUTRjrwfMepT3d2z8aT6hxv4yu8EDdooZq/2Bn/vjMI32xw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.10.13:
-    resolution: {integrity: sha512-S5XySRfW2AmnTeY1IT+Jdr6Goq7mxWganVFfrmqU+qqq3Om/nr0GkcUX+KTIo9mPrN0D3p5QViBRzulwB5iuUQ==}
+  /turbo-windows-64@1.10.14:
+    resolution: {integrity: sha512-zKNS3c1w4i6432N0cexZ20r/aIhV62g69opUn82FLVs/zk3Ie0GVkSB6h0rqIvMalCp7enIR87LkPSDGz9K4UA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.10.13:
-    resolution: {integrity: sha512-nKol6+CyiExJIuoIc3exUQPIBjP9nIq5SkMJgJuxsot2hkgGrafAg/izVDRDrRduQcXj2s8LdtxJHvvnbI8hEQ==}
+  /turbo-windows-arm64@1.10.14:
+    resolution: {integrity: sha512-rkBwrTPTxNSOUF7of8eVvvM+BkfkhA2OvpHM94if8tVsU+khrjglilp8MTVPHlyS9byfemPAmFN90oRIPB05BA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.10.13:
-    resolution: {integrity: sha512-vOF5IPytgQPIsgGtT0n2uGZizR2N3kKuPIn4b5p5DdeLoI0BV7uNiydT7eSzdkPRpdXNnO8UwS658VaI4+YSzQ==}
+  /turbo@1.10.14:
+    resolution: {integrity: sha512-hr9wDNYcsee+vLkCDIm8qTtwhJ6+UAMJc3nIY6+PNgUTtXcQgHxCq8BGoL7gbABvNWv76CNbK5qL4Lp9G3ZYRA==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.13
-      turbo-darwin-arm64: 1.10.13
-      turbo-linux-64: 1.10.13
-      turbo-linux-arm64: 1.10.13
-      turbo-windows-64: 1.10.13
-      turbo-windows-arm64: 1.10.13
+      turbo-darwin-64: 1.10.14
+      turbo-darwin-arm64: 1.10.14
+      turbo-linux-64: 1.10.14
+      turbo-linux-arm64: 1.10.14
+      turbo-windows-64: 1.10.14
+      turbo-windows-arm64: 1.10.14
     dev: true
 
   /tw-to-css@0.0.11:


### PR DESCRIPTION
Le but ici est d'avoir un system de couleurs / style plus simple a comprendre.

Avant on avait beaucoup de granularité, ce qui est bien.
`bg-popper text-popper-foreground`

Mais le soucis est qu'on en s'y retrouve pas et que ça fait beaucoup de variantes de couleurs. Cette mr simplifie tout ça en replaçant toutes les classes/variables par
`bg-primary text-primary`
et des détails avec `bg-secondary bg-tertirary` / `text-secondary text-muted`
Rien de plus.

Les couleurs n'ont pas disparu, elles sont simplement renommées et regroupées